### PR TITLE
Add styles for Jekyll syntax highlighting

### DIFF
--- a/element.css
+++ b/element.css
@@ -151,9 +151,6 @@ blockquote cite::before {
 code {
 	display: inline-block;
 	padding: 0.1rem;
-	background-color: #F5F5F5;
-	background-color: rgba(0, 0, 0, 0.04);
-	color: #333;
 	font-size: 0.9rem;
 	font-family: hack, Courier, monospace;
 	border-radius: 0.2em;
@@ -163,8 +160,6 @@ code {
 pre > code {
 	display: block;
 	padding: 1rem;
-	background-color: rgb(51, 51, 51);
-	color: rgb(255, 249, 217);
 	border-radius: 0.3rem;
 	overflow-x: auto;
 }

--- a/jekyll-highlight.css
+++ b/jekyll-highlight.css
@@ -1,0 +1,331 @@
+.highlight  {
+	background: var(--highlight-background, #ffffff);
+}
+
+/* Comment */
+.highlight .c {
+	color: var(--highlight-comment-color, #999988);
+	font-style: italic;
+}
+
+/* Error */
+.highlight .err {
+	color: var(--highlight-error-color, #a61717);
+	background: var(--highlight-error-background, #e3d2d2);
+}
+
+/* Keyword */
+.highlight .k {
+	font-weight: bold;
+}
+
+/* Operator */
+.highlight .o {
+	font-weight: bold;
+}
+
+/* Comment.Multiline */
+.highlight .cm {
+	color: var(--highlight-comment-multi-color, var(--highlight-comment-color, #999988));
+	font-style: italic;
+}
+
+/* Comment.Preproc */
+.highlight .cp {
+	color: var(--highlight-comment-preprocessor, #999999);
+	font-weight: bold;
+}
+
+/* Comment.Single */
+.highlight .c1 {
+	color: var(--highlight-comment-single-color, var(--highlight-comment-color, #999988));
+	font-style: italic;
+}
+
+/* Comment.Special */
+.highlight .cs {
+	color: var(--highlight-comment-special-color, #999999);
+	font-weight: bold;
+	font-style: italic;
+}
+
+/* Generic.Deleted */
+.highlight .gd {
+	color: var(--highlight-generic-deleted-color, #000000);
+	background-color: var(--highlight-generic-deleted-background, #ffdddd);
+}
+
+/* Generic.Deleted.Specific */
+.highlight .gd .x {
+	color: var(--highlight-generic-deleted-specific-color, #000000);
+	background-color: var(--highlighted-generic-deleted-specific-background, #ffaaaa);
+}
+
+/* Generic.Emph */
+.highlight .ge {
+	font-style: italic;
+}
+
+/* Generic.Error */
+.highlight .gr {
+	color: var(--highlighted-generic-error-color, #aa0000);
+}
+
+/* Generic.Heading */
+.highlight .gh {
+	color: var(--highlight-generic-heading-color, #999999);
+}
+
+/* Generic.Inserted */
+.highlight .gi {
+	color: var(--highlight-generic-inserted-color, color: var(--highlight-generic-inserted-color, #000000));
+	background-color: var(--highlight-generic-inserted-background, #ddffdd);
+}
+
+/* Generic.Inserted.Specific */
+.highlight .gi .x {
+	color: var(--highlight-generic-inserted-specific-color, color: var(--highlight-generic-inserted-color, #000000));
+	background-color: var(--highlight-generic-inserted-specific-background, var(--highlight-generic-inserted-background, #ddffdd));
+}
+
+/* Generic.Output */
+.highlight .go {
+	color: var(--highlight-generic-output-color, #888888);
+}
+
+/* Generic.Prompt */
+.highlight .gp {
+	color: var(--highlight-generic-prompt-color, #555555);
+}
+
+/* Generic.Strong */
+.highlight .gs {
+	font-weight: bold;
+}
+
+/* Generic.Subheading */
+.highlight .gu {
+	color: var(--highlight-generic-subheading-color, #aaaaaa);
+}
+
+/* Generic.Traceback */
+.highlight .gt {
+	color: var(--highlight-generic-traceback-color, #aa0000);
+}
+
+/* Keyword.Constant */
+.highlight .kc {
+	font-weight: bold;
+}
+
+/* Keyword.Declaration */
+.highlight .kd {
+	font-weight: bold;
+}
+
+/* Keyword.Pseudo */
+.highlight .kp {
+	font-weight: bold;
+}
+
+/* Keyword.Reserved */
+.highlight .kr {
+	font-weight: bold;
+}
+
+/* Keyword.Type */
+.highlight .kt {
+	color: var(--highlight-keyword-type-color, #445588);
+	font-weight: bold;
+}
+
+/* Literal.Number */
+.highlight .m {
+	color: var(--highlight-literal-number-color, #009999);
+}
+
+/* Literal.String */
+.highlight .s {
+	color: var(--highlight-literal-string-color, #d14);
+}
+
+/* Name.Attribute */
+.highlight .na {
+	color: var(--highlight-name-attribute-color, #008080);
+}
+
+/* Name.Builtin */
+.highlight .nb {
+	color: var(--highlight-name-builtin-color, #0086B3);
+}
+
+/* Name.Class */
+.highlight .nc {
+	color: var(--highlight-name-class-color, #445588);
+	font-weight: bold;
+}
+
+/* Name.Constant */
+.highlight .no {
+	color: var(--highlight-name-constant-color, #008080);
+}
+
+/* Name.Entity */
+.highlight .ni {
+	color: var(--highlight-name-entity-color, #800080);
+}
+
+/* Name.Exception */
+.highlight .ne {
+	color: var(--highlight-name-exception-color, #990000);
+	font-weight: bold;
+}
+
+/* Name.Function */
+.highlight .nf {
+	color: var(--highlight-name-function-color, #990000);
+	font-weight: bold;
+}
+
+/* Name.Namespace */
+.highlight .nn {
+	color: var(--highlight-name-namespace-color, #555555);
+}
+
+/* Name.Tag */
+.highlight .nt {
+	color: var(--highlight-name-tag-color, #000080);
+}
+
+/* Name.Variable */
+.highlight .nv {
+	color: var(--highlight-name-variable-color, #008080);
+}
+
+/* Operator.Word */
+.highlight .ow {
+	font-weight: bold;
+}
+
+/* Text.Whitespace */
+.highlight .w {
+	color: var(--highlight-text-whitespace-color, #bbbbbb);
+}
+
+/* Literal.Number.Float */
+.highlight .mf {
+	color: var(--highlight-literal-float-color, var(--highlight-literal-number-color, #009999));
+}
+
+/* Literal.Number.Hex */
+.highlight .mh {
+	color: var(--highlight-literal-hex-color, var(--highlight-literal-number-color, #009999));
+}
+
+/* Literal.Number.Integer */
+.highlight .mi {
+	color: var(--highlight-literal-integer-color, var(--highlight-literal-number-color, #009999));
+}
+
+/* Literal.Number.Oct */
+.highlight .mo {
+	color: var(--highlight-literal-octal-color, var(--highlight-literal-number-color, #009999));
+}
+
+/* Literal.String.Backtick */
+.highlight .sb {
+	color: var(--highlight-literal-string-backtic-color, var(--highlight-literal-string, #d14));
+}
+
+/* Literal.String.Char */
+.highlight .sc {
+	color: var(--highlight-literal-string-char-color, var(--highlight-literal-string, #d14));
+}
+
+/* Literal.String.Doc */
+.highlight .sd {
+	color: var(--highlight-literal-string-doc-color, var(--highlight-literal-string, #d14));
+}
+
+/* Literal.String.Double */
+.highlight .s2 {
+	color: var(--highlight-literal-string-double-color, var(--highlight-literal-string, #d14));
+}
+
+/* Literal.String.Escape */
+.highlight .se {
+	color: var(--highlight-literal-string-escape-color, var(--highlight-literal-string, #d14));
+}
+
+/* Literal.String.Heredoc */
+.highlight .sh {
+	color: var(--highlight-literal-string-heredoc-color, var(--highlight-literal-string, #d14));
+}
+
+/* Literal.String.Interpol */
+.highlight .si {
+	color: var(--highlight-literal-string-interpol-color, var(--highlight-literal-string, #d14));
+}
+
+/* Literal.String.Other */
+.highlight .sx {
+	color: var(--highlight-literal-string-other-color, var(--highlight-literal-string, #d14));
+}
+
+/* Literal.String.Regex */
+.highlight .sr {
+	color: var(--highlight-literal-string-regex-color, #009926);
+}
+
+/* Literal.String.Single */
+.highlight .s1 {
+	color: var(--highlight-literal-string-single-color, var(--highlight-literal-string, #d14));
+}
+
+/* Literal.String.Symbol */
+.highlight .ss {
+	color: var(--highlight-literal-string-symbol-color, #990073);
+}
+
+/* Name.Builtin.Pseudo */
+.highlight .bp {
+	color: var(--highlight-name-builtin-pseudo-color, #999999);
+}
+
+/* Name.Variable.Class */
+.highlight .vc {
+	color: var(--highlight-name-variable-class-color, #008080);
+}
+
+/* Name.Variable.Global */
+.highlight .vg {
+	color: var(--highlight-name-variable-global-color, #008080);
+}
+
+/* Name.Variable.Instance */
+.highlight .vi {
+	color: var(--highlight-name-variable-instance-color, #008080);
+}
+
+/* Literal.Number.Integer.Long */
+.highlight .il {
+	color: var(--highlight-literal-integer-long-color, var(--highlight-literal-integer-color, var(--highlight-literal-number-color, #009999)));
+}
+
+/* Make line numbers unselectable: excludes line numbers from copy-paste user ops */
+.highlight .lineno {
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	-o-user-select: none;
+	user-select: none;
+}
+
+/* Mozilla specific */
+.highlight .lineno::-moz-selection {
+	background-color: var(--highlight-lineno-background, transparent);
+}
+
+/* Other major browsers */
+.highlight .lineno::selection {
+	background-color: var(--highlight-lineno-background, transparent);
+}


### PR DESCRIPTION
## Add stylesheet for Jekyll's `{% highlight %}`. Resolves #21 

### List of significant changes made
- Add `jekyll-highlight.css`
- Remove `pre`, `code`, & `pre > code` colors & backgrounds
- Allow to inherit where possible

