### PR TITLE
Fix mobile layout column width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 <!-- markdownlint-disable -->
+## [v2.2.2] - 2020-07-09
+
+### Fixed
+- Fix setting column / page width on mobile layouts [#81](https://github.com/shgysk8zer0/core-css/issues/81)
+
 ## [v2.2.1] - 2020-06-27
 
 ### Changed

--- a/layout/default/index.css
+++ b/layout/default/index.css
@@ -13,7 +13,7 @@
 	:root:not([data-layout]) > body.grid, :root[data-layout="default"] > body.grid, body.grid {
 		grid-template-areas: 'header' 'nav' 'main' 'sidebar' 'footer';
 		grid-template-rows: calc(100vh - var(--nav-height, 4rem)) var(--nav-height, 4rem) minmax(75vh, auto) minmax(200px, auto) minmax(300px, auto);
-		grid-template-columns: auto;
+		grid-template-columns: 100%;
 		grid-column-gap: 0;
 	}
 }

--- a/layout/left-sidebar/index.css
+++ b/layout/left-sidebar/index.css
@@ -13,7 +13,7 @@
 	:root[data-layout="left-sidebar"] > body.grid {
 		grid-template-areas: 'header' 'nav' 'main' 'sidebar' 'footer';
 		grid-template-rows: minmax(var(--header-height, 400px), auto) var(--nav-height, 4rem) minmax(var(--main-height, 75vh), auto) minmax(var(--footer-height, 300px), auto);
-		grid-template-columns: auto;
+		grid-template-columns: 100%;
 		grid-column-gap: 0;
 	}
 }

--- a/layout/right-sidebar/index.css
+++ b/layout/right-sidebar/index.css
@@ -13,7 +13,7 @@
 	:root[data-layout="right-sidebar"] > body.grid {
 		grid-template-areas: 'header' 'nav' 'main' 'sidebar' 'footer';
 		grid-template-rows: minmax(var(--header-height, 400px), auto) var(--nav-height, 4rem) minmax(var(--main-height, 75vh), auto) minmax(var(--footer-height, 300px), auto);
-		grid-template-columns: auto;
+		grid-template-columns: 100%;
 		grid-column-gap: 0;
 	}
 }


### PR DESCRIPTION
Change `grid-template-columns` from `auto` to `100%`. Resolves #81