### PR TITLE
Add stylesheet for <table> styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Styles for `<table class="themed-table">`
+- Missing rules for `overflow: hidden`
 
 ### Removed
 - Applying styles to `<button>`s without the `.btn` class

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v2.3.1]
+
+### Added
+- Styles for `<table class="themed-table">`
+
 ### Removed
 - Applying styles to `<button>`s without the `.btn` class
 

--- a/table.css
+++ b/table.css
@@ -1,0 +1,43 @@
+table.themed-table {
+	background-color: var(--table-background, #fefefe);
+	position: relative;
+}
+
+table.themed-table thead, table.themed-table tfoot {
+	background-color: var(--table-header-background, var(--accent-color, #5050ff));
+	color: var(--table-header-color,  #fafafa);
+	box-shadow: 0 4px 2px rgba(0, 0, 0, 0.3);
+}
+
+table.themed-table thead th, table.themed-table tfoot th {
+	padding: var(--table-th-v-padding, 0.4em) var(--table-th-h-padding, 0.6em);
+}
+
+table.themed-table tbody td {
+	padding: var(--table-cell-v-padding, 0.2em) var(--table-cell-h-padding, 0.5em);
+	color: var(--table-cell-color, #242424);
+	cursor: cell;
+	transition: color 300ms ease-in-out, background-color 300ms ease-in-out;
+}
+
+table.themed-table tbody td:hover {
+	background-color: var(--table-cell-hover-background, var(--accent-color, #5050ff));
+	color: var(--table-cell-hover-color, #fafafa);
+}
+
+table.themed-table tbody tr {
+	outline: 3px solid transparent;
+	transition: outline-color 300ms ease-in-out;
+}
+
+table.themed-table tbody tr:hover {
+	outline-color: var(--table-row-hover-outline-color, var(--accent-color, #5050ff));
+}
+
+table.themed-table tbody tr:nth-child(odd) {
+	background-color: var(--table-row-odd-background, #fafafa);
+}
+
+table.themed-table tbody tr:nth-child(even) {
+	background-color: var(--table-row-even-background, #E7E7E7);
+} 

--- a/utility.css
+++ b/utility.css
@@ -497,6 +497,10 @@
 	overflow: scroll;
 }
 
+.overflow-auto {
+	overflow: auto;
+}
+
 .overflow-x-hidden {
 	overflow-x: hidden;
 }
@@ -509,6 +513,10 @@
 	overflow-x: scroll;
 }
 
+.overflow-x-auto {
+	overflow-x: auto;
+}
+
 .overflow-y-hidden {
 	overflow-y: hidden;
 }
@@ -519,6 +527,10 @@
 
 .overflow-y-scroll {
 	overflow-y: scroll;
+}
+
+.overflow-y-auto {
+	overflow-y: auto;
 }
 
 /*=========================== Object Fit =========================*/


### PR DESCRIPTION
Requires class of `.themed.-table`

Also adds missing rules for `overflow: auto`