### PR TITLE
Use `--viewport-height` when setting default layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Use optional `--viewport-height` when setting header height in layout, dealing with URL bar
+
 ## [v2.3.1] - 2020-08-01
 
 ### Added

--- a/layout/default/index.css
+++ b/layout/default/index.css
@@ -3,7 +3,7 @@
 @media screen {
 	:root:not([data-layout]) > body.grid, :root[data-layout="default"] > body.grid {
 		grid-template-areas: 'header header header' 'nav nav nav' '. main sidebar' 'footer footer footer';
-		grid-template-rows: calc(100vh - var(--nav-height, 4rem)) var(--nav-height, 4rem) minmax(var(--main-height, 75vh), auto) minmax(var(--footer-height, 300px), auto);
+		grid-template-rows: calc(var(--viewport-height, 100vh) - var(--nav-height, 4rem)) var(--nav-height, 4rem) minmax(var(--main-height, 75vh), auto) minmax(var(--footer-height, 300px), auto);
 		grid-template-columns: auto minmax(var(--main-min-width, 320px), var(--main-max-width, 1200px)) minmax(var(--sidebar-min-width, 300px), var(--sidebar-max-width, 400px));
 		grid-column-gap: 1.2em;
 	}
@@ -12,7 +12,7 @@
 @media (max-width: 800px) {
 	:root:not([data-layout]) > body.grid, :root[data-layout="default"] > body.grid, body.grid {
 		grid-template-areas: 'header' 'nav' 'main' 'sidebar' 'footer';
-		grid-template-rows: calc(100vh - var(--nav-height, 4rem)) var(--nav-height, 4rem) minmax(75vh, auto) minmax(200px, auto) minmax(300px, auto);
+		grid-template-rows: calc(var(--viewport-height, 100vh) - var(--nav-height, 4rem)) var(--nav-height, 4rem) minmax(75vh, auto) minmax(200px, auto) minmax(300px, auto);
 		grid-template-columns: 100%;
 		grid-column-gap: 0;
 	}


### PR DESCRIPTION
Deals with the URL bar when determining what `100vh` should mean. Needs to be set by JavaScript, since this is currently lacking in CSS alone.
