### PR TITLE
Add styles for `.btn.btn-outline`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Styles for `.btn.btn-outline`
+
 ## [2.4.0] - 2020-11-25
 
 ### Added

--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@
 		<nav id="nav" class="sticky top shadow background-primary color-alt adwaita-toolbar no-print z-4 contain-content flex row no-wrap">
 			<span class="mobile-hidden"><button>Vanilla</button></span>
 			<button type="button" class="btn btn-default grow-1">Default</button>
+			<button type="button" class="btn btn-outline grow-1">Outline</button>
 			<button type="button" class="btn btn-primary grow-1">Primary</button>
 			<button type="button" class="btn btn-accept grow-1">Accept</button>
 			<button type="button" class="btn btn-reject grow-1">Reject</button>

--- a/utility.css
+++ b/utility.css
@@ -1348,6 +1348,13 @@
 	color: var(--button-reject-active-color, var(--button--reject-color, var(--button-active-color)));
 }
 
+.btn.btn-outline {
+	color: var(--button-outline-color, var(--accent-color, #007bff));
+	background-color: var(--button-outline-background, transparent);
+	border: var(--button-outline-border, 2px solid currentColor);
+	border-radius: var(--button-outline-border-radius, 12px);
+}
+
 @media (max-width: 800px) {
 	.mobile-hidden {
 		display: none;


### PR DESCRIPTION
Creates a button with a border of `currentColor` instead of a filled button with background.

![image](https://user-images.githubusercontent.com/1627459/102698985-4debee80-41f6-11eb-8f58-ad1ff04d5c11.png)

