### PR TITLE
Fix invalid query for `[data-theme="dark"] .adwaita-toolbar`

### DIFF
--- a/theme/adwaita/extras.css
+++ b/theme/adwaita/extras.css
@@ -6,7 +6,7 @@
 	color: var(--primary-color);
 }
 
-:root([data-theme="dark"]) .adwaita-toolbar {
+:root[data-theme="dark"] .adwaita-toolbar {
 	background-image: linear-gradient(#2b2b2b, #262626);
 	border-bottom: 1px solid #070707;
 }


### PR DESCRIPTION
Fixes issue when system preferences is set to light mode but attribute or cookie sets it to dark mode.
